### PR TITLE
Fix SQL exception when executing query

### DIFF
--- a/includes/UserPageViewTrackerPager.php
+++ b/includes/UserPageViewTrackerPager.php
@@ -44,7 +44,7 @@ class UserPageViewTrackerPager extends AlphabeticPager {
 		$conds[] = 'u.user_id=v.user_id AND p.page_id=v.page_id';
 		$prefix = $this->getConfig()->get( 'DBprefix' );
 		return [
-			'tables' => '(' . $prefix . 'user u JOIN ' . $prefix . 'page p) JOIN ' . $prefix . 'user_page_views v',
+			'tables' => ['u' => 'user', 'p' => 'page', 'v' => 'user_page_views'], 
 			'fields' => [
 				'rownum' => '@rownum+1',
 				'user_name' => 'u.user_name',


### PR DESCRIPTION
When installing the extension on MediaWiki 1.42.1 with MariaDB 11.3.2 in Bitnami container, I faced this error.

```
Table 'bitnami_mediawiki.user u JOIN page p JOIN user_page_views v' doesn't exist
```

![CleanShot 2024-10-03 at 16 30 50@2x](https://github.com/user-attachments/assets/c540d67a-8243-4b8a-9c09-3026619e3a5a)

Apply the patch fixed this.